### PR TITLE
Fix vm crash when using longest_prefix() (with py3k)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
     - 2.7
     - 3.5
     - 3.6
-    - 3.7
 
 install:
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+    - 2.7
+    - 3.5
+    - 3.6
+    - 3.7
+
+install:
+    - python setup.py install
+script:
+    - pytest -v
+

--- a/src/pyapi.c
+++ b/src/pyapi.c
@@ -600,10 +600,9 @@ PyTrie_has_node(PyTrie *self, PyObject *args)
 }
 
 static PyObject *
-PyTrie_longest_prefix(PyTrie *self, PyObject *args, PyObject *kwds)
+PyTrie_longest_prefix(PyTrie *self, PyObject *args)
 {
     const char *key;
-    static char *kwlist[] = {"key", NULL};
 
 #ifdef IS_PY3K
     const char format[] = "y";
@@ -611,7 +610,7 @@ PyTrie_longest_prefix(PyTrie *self, PyObject *args, PyObject *kwds)
     const char format[] = "s";
 #endif
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, format, kwlist, &key))
+    if (!PyArg_ParseTuple(args, format, &key))
         return NULL;
 
     const TrieItem *item = trie_longest_prefix(self->root, key);

--- a/src/pyapi.c
+++ b/src/pyapi.c
@@ -600,9 +600,10 @@ PyTrie_has_node(PyTrie *self, PyObject *args)
 }
 
 static PyObject *
-PyTrie_longest_prefix(PyTrie *self, PyObject *args)
+PyTrie_longest_prefix(PyTrie *self, PyObject *args, PyObject *kwds)
 {
     const char *key;
+    static char *kwlist[] = {"key", NULL};
 
 #ifdef IS_PY3K
     const char format[] = "y";
@@ -610,7 +611,7 @@ PyTrie_longest_prefix(PyTrie *self, PyObject *args)
     const char format[] = "s";
 #endif
 
-    if (!PyArg_ParseTuple(args, format, &key))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, format, kwlist, &key))
         return NULL;
 
     const TrieItem *item = trie_longest_prefix(self->root, key);
@@ -1059,7 +1060,7 @@ static PyMethodDef PyTrie_methods[] = {
     {"has_node",        (PyCFunction)PyTrie_has_node, METH_VARARGS,
         has_node__doc__},
     {"longest_prefix",  (PyCFunction)PyTrie_longest_prefix,
-        METH_VARARGS, longest_prefix__doc__},
+        METH_VARARGS | METH_KEYWORDS, longest_prefix__doc__},
     {"suffixes",        (PyCFunction)PyTrie_suffixes,
         METH_VARARGS, suffixes__doc__},
     {"neighbors",       (PyCFunction)PyTrie_neighbors,

--- a/tests/test_vtrie.py
+++ b/tests/test_vtrie.py
@@ -454,6 +454,10 @@ def test_longest_prefix():
     del t[b"foo"]
     assert t.longest_prefix(b"foozle") == ("fo", 1)
 
+    # testing with named argument
+    assert t.longest_prefix(key=b"foozle") == ("fo", 1)
+    assert t.longest_prefix(key=b"foobar") == ("foobar", 3)
+
 def test_suffixes():
     t = Trie()
     t[b"production"] = 1


### PR DESCRIPTION
see #1 